### PR TITLE
Introduced new setting for Kodi installations in headless mode.

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -166,18 +166,21 @@ class EventHandler(FileSystemEventHandler):
 
 
 def main():
-    progress = xbmcgui.DialogProgressBG()
-    progress.create("Watchdog starting. Please wait...")
+    if not settings.ISHEADLESS:
+        progress = xbmcgui.DialogProgressBG()
+        progress.create("Watchdog starting. Please wait...")
 
     if settings.STARTUP_DELAY > 0:
         log("waiting for user delay of %d seconds" % settings.STARTUP_DELAY)
         msg = "Delaying startup by %d seconds."
-        progress.update(0, message=msg % settings.STARTUP_DELAY)
+        if not settings.ISHEADLESS:
+            progress.update(0, message=msg % settings.STARTUP_DELAY)
         start = time.time()
         while time.time() - start < settings.STARTUP_DELAY:
             xbmc.sleep(100)
             if xbmc.abortRequested:
-                progress.close()
+                if not settings.ISHEADLESS:
+                    progress.close()
                 return
 
     sources = []
@@ -206,7 +209,8 @@ def main():
     observer.start()  # start so emitters are started on schedule
 
     for i, (libtype, path) in enumerate(sources):
-        progress.update((i+1)/len(sources)*100, message="Setting up %s" % path)
+        if not settings.ISHEADLESS:
+            progress.update((i+1)/len(sources)*100, message="Setting up %s" % path)
         try:
             emitter_cls = emitters.select_emitter(path)
         except IOError:
@@ -228,10 +232,11 @@ def main():
                 break
 
     xbmcif.start()
-    progress.close()
+    if not settings.ISHEADLESS:
+        progress.close()
     log("initialization done")
 
-    if settings.SHOW_STATUS_DIALOG:
+    if settings.SHOW_STATUS_DIALOG and not settings.ISHEADLESS:
         watching = ["Watching '%s'" % path for _, path in sources
                     if path in observer.paths]
         not_watching = ["Not watching '%s'" % path for _, path in sources

--- a/core/settings.py
+++ b/core/settings.py
@@ -35,6 +35,7 @@ CLEAN_ON_START = ADDON.getSetting('cleanonstart') == 'true'
 SCAN_ON_START = ADDON.getSetting('scanonstart') == 'true'
 PER_FILE_REMOVE = int(ADDON.getSetting('removalmethod')) == 1
 SHOW_PROGRESS_DIALOG = ADDON.getSetting('hideprogress') == 'false'
+ISHEADLESS = ADDON.getSetting('isheadless')
 
 
 if ADDON.getSetting('watchvideo') == 'true':

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -48,5 +48,6 @@
     <string id="30055">Clean entire library</string>
     <string id="30056">Remove from library when files are removed</string>
     <string id="30057">Hide progress of library scan/clean (Helix only)</string>
+    <string id="30058">Running Kodi in headless mode</string>
 </strings>
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,7 @@
         <setting label="30048" id="pauseonplayback" type="bool" default="true"/>
         <setting label="30057" id="hideprogress" type="bool" default="true"/>
         <setting label="30053" id="showstatusdialog" type="bool" default="false"/>
+        <setting label="30058" id="isheadless" type="bool" default="false" visible="false"/>
         <setting label="30018" type="lsep"/>
         <setting label="30019" type="lsep"/>
     </category>


### PR DESCRIPTION
New setting used to suppress any GUI output for installations running in headless mode, which will otherwise cause the addon to crash when a window manager is not installed.

The setting is "hidden" in the GUI and by default set to false in order to not affect standard GUI-based installations. People running headless mode would have to manually edit the settings.xml file to change the setting to true in an editor.